### PR TITLE
Support end-to-end testing of Mine Support in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ PostgreSQL
 Message queue - amqp protocol
 
 # Running the application
-The application is ready to run:
+The application is designed to run as a container via Docker Compose or Kubernetes (with Helm).
 
-`$ node index.js`
+A convenience script is provided to run via Docker Compose:
 
-Alternatively the project can be run in a container through the docker-compose.yaml file.
+`scripts/start`
+
+This will create the required `mine-support` network before starting the service so that it can communicate with other Mine Support services running alongside it through docker-compose. The script will then attach to the running service, tailing its logs and allowing the service to be brought down by pressing `Ctrl + C`.
 
 # Kubernetes
 The service has been developed with the intention of running in Kubernetes.  A helm chart is included in the `.\helm` folder.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  mine-support-claim-service:
+  mine-support-payment-service:
     build: .
     image: mine-support-payment-service
     container_name: mine-support-payment-service

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,5 +4,11 @@ services:
     build: .
     image: mine-support-payment-service
     container_name: mine-support-payment-service
+    networks:
+      - mine-support
     ports:
-        - "3004:3004"
+      - "3004:3004"
+
+networks:
+  mine-support:
+    external: true

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker network inspect mine-support &>/dev/null || docker network create mine-support
+
+docker-compose down -v
+docker-compose build --no-cache mine-support-payment-service
+docker-compose up --force-recreate mine-support-payment-service


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-284

This is part of a set of changes being made to all Mine Support
microservices to enable them to run alongside each other in
containerised development environments.