### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,17 +17,21 @@ spec:
         redeployOnChange: {{ .Values.container.redeployOnChange | quote }}
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
-      containers:   
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
+      containers:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}
         {{- if .Values.container.command }}
         {{- with .Values.container.command }}
-          command:
-            {{- toYaml . | nindent 12 }}
+        command:
+          {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with .Values.container.args }}
-          args:
-            {{- toYaml . | nindent 12 }}
+        args:
+          {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.container.imagePullPolicy }}
@@ -36,7 +40,7 @@ spec:
           runAsNonRoot: {{ .Values.container.runAsNonRoot }}
           readOnlyRootFilesystem: {{ .Values.container.readOnlyRootFilesystem }}
           allowPrivilegeEscalation: {{ .Values.container.allowPrivilegeEscalation }}
-        env:                
+        env:
         - name: NODE_ENV
           value: {{ .Values.environment }}
         - name: POSTGRES_USERNAME
@@ -71,8 +75,6 @@ spec:
           value: "3004"
         ports:
         - containerPort: {{ .Values.container.port }}
-        command: ["/bin/sh","-c"]
-        args: ["sequelize db:migrate; node index"]
         resources:
           requests:
             memory: {{ .Values.container.requestMemory }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,6 +7,7 @@ postgresExternalName: host.docker.internal
 postgresPort: 5432
 name: mine-support-payment-service
 image: mine-support-payment-service
+imagePullSecret:
 service:
   type: ClusterIP
   port: 80
@@ -34,6 +35,8 @@ container:
   paymentQueueAddress: payment
   paymentQueueUser: artemis
   paymentQueuePassword: artemis
+  command: ["/bin/sh","-c"]
+  args: ["npm --no-update-notifier run migrate; node index"]  
 replicaCount: 1
 minReadySeconds: 10
 maxSurge: 1


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.